### PR TITLE
Replace all hardcoded IDs, implement dotenv, fixed requirements

### DIFF
--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands
 from discord import utils
@@ -26,11 +27,11 @@ class Channels(commands.Cog):
     async def subscribe(self, ctx, channel: discord.TextChannel = None):
 
         # bot_commands channel
-        if ctx.channel.id == 598564981989965854 and channel:
+        if ctx.channel.id == os.getenv("BOT_COMMANDS_CHANNEL") and channel:
             role = self.get_news_role(ctx, channel)
         
         # Not bot_commands channel, but is a channel in "Libraries" or "Frameworks" categories
-        elif (ctx.channel.id != 598564981989965854 or ctx.channel.category_id == 361587040749355018 or ctx.channel.category_id == 361587387538604054) and not channel:
+        elif (ctx.channel.id != os.getenv("BOT_COMMANDS_CHANNEL") or ctx.channel.category_id == os.getenv("LIBRARIES_CATEGORY") or ctx.channel.category_id == os.getenv("FRAMEWORKS_CATEGORY")) and not channel:
             role = self.get_news_role(ctx)
         else:
             return

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands
 
@@ -9,7 +10,7 @@ class Logging(commands.Cog):
     # Message Logging
     @commands.Cog.listener()
     async def on_message_delete(self, message):
-        channel = self.bot.get_channel(709176997233950790) # message-logs channel
+        channel = self.bot.get_channel(os.getenv("MESSAGE_LOGS_CHANNEL")) # message-logs channel
         
         # Avoid duplicate channel; i.e message delete from log channel
         if message.channel == channel:
@@ -27,7 +28,7 @@ class Logging(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message_edit(self, before, after):
-        channel = self.bot.get_channel(709176997233950790) # message-logs channel
+        channel = self.bot.get_channel(os.getenv("MESSAGE_LOGS_CHANNEL")) # message-logs channel
     
         # If message data is malformed or blank, return
         if (before.content == "") or (after.content == ""):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands
 from discord import utils
@@ -28,7 +29,7 @@ class Moderation(commands.Cog):
     async def mute(self, ctx, member: discord.Member, duration, *, message):
         role = utils.get(ctx.guild.roles, name="Muted")
         channel = ctx.message.channel
-        log_channel = self.bot.get_channel(709262930750865440) # moderation-logs channel
+        log_channel = self.bot.get_channel(os.getenv("MODERATION_LOGS_CHANNEL")) # moderation-logs channel
 
         # Create default embed
         emb = discord.Embed()
@@ -67,7 +68,7 @@ class Moderation(commands.Cog):
     async def unmute(self, ctx, member: discord.Member, *, message):
         role = utils.get(ctx.guild.roles, name="Muted")
         channel = ctx.message.channel
-        log_channel = self.bot.get_channel(709262930750865440) # moderation-logs channel
+        log_channel = self.bot.get_channel(os.getenv("MODERATION_LOGS_CHANNEL")) # moderation-logs channel
 
         # Create default embed
         emb = discord.Embed()
@@ -103,7 +104,7 @@ class Moderation(commands.Cog):
     @commands.has_role("Library Developer" or "Moderator")
     async def warn(self, ctx, member: discord.Member, *, message):
         channel = ctx.message.channel
-        log_channel = self.bot.get_channel(709262930750865440) # moderation-logs channel
+        log_channel = self.bot.get_channel(os.getenv("MODERATION_LOGS_CHANNEL")) # moderation-logs channel
 
         # Create default embed
         emb = discord.Embed()
@@ -166,7 +167,7 @@ class Moderation(commands.Cog):
     @commands.command()
     @commands.has_role("Moderator")
     async def clean(self, ctx, amount, member: discord.Member = None):
-        log_channel = self.bot.get_channel(709262930750865440) # moderation-logs channel
+        log_channel = self.bot.get_channel(os.getenv("MODERATION_LOGS_CHANNEL")) # moderation-logs channel
         emb = discord.Embed()
         emb.set_author(name="Moderation", icon_url="https://cdn.discordapp.com/attachments/336577284322623499/683028692133216300/ac6e275e1f638f4e19af408d8440e1d1.png")
         emb.set_footer(text=f'\t\t\t\t\t\t\tTimestamp: {ctx.message.created_at}')

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands
 from discord import utils
@@ -19,7 +20,7 @@ class Verification(commands.Cog):
     # Verification on member join
     @commands.Cog.listener()
     async def on_member_join(self, member):
-        channel = self.bot.get_channel(718621539653648424) # join-logs channel
+        channel = self.bot.get_channel(os.getenv("JOIN_LOGS_CHANNEL")) # join-logs channel
         role = utils.get(member.guild.roles, name="Verified")
         response = requests.get(f'https://verify.eryn.io/api/user/{member.id}').json()
         
@@ -47,7 +48,7 @@ class Verification(commands.Cog):
     async def verify(self, ctx, username : str = None, *, keyPhrase : str = None):
         member = ctx.message.author
         role = utils.get(ctx.guild.roles, name="Verified")
-        channel = self.bot.get_channel(718621539653648424) # join-logs channel
+        channel = self.bot.get_channel(os.getenv("JOIN_LOGS_CHANNEL")) # join-logs channel
         response = requests.get(f'https://verify.eryn.io/api/user/{member.id}').json()
 
         result = db.verificationEntry.check_discordid(member.id)
@@ -118,7 +119,7 @@ class Verification(commands.Cog):
     async def force_verify(self, ctx, username, member: discord.Member):
         role = utils.get(ctx.guild.roles, name="Verified")
         userid = requests.get(f'https://api.roblox.com/users/get-by-username?&username={username}').json()["Id"]
-        channel = self.bot.get_channel(718621539653648424) # join-logs channel
+        channel = self.bot.get_channel(os.getenv("JOIN_LOGS_CHANNEL")) # join-logs channel
         
         # Prevent overwrite
         result = db.verificationEntry.check_discordid(member.id)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
+import os
 import discord
 from discord.ext import commands
 
-import docstoken
+from dotenv import load_dotenv
+load_dotenv()
 
 # A list containing all cogs that we want to load
 available_cogs = ['cogs.maintenance', 'cogs.logging', 'cogs.utility', 'cogs.channels', 'cogs.moderation', 'cogs.verification', 'cogs.tagging']
@@ -24,4 +26,4 @@ if __name__ == '__main__':
         bot.load_extension(cog)
     
     # Run Bot
-    bot.run(docstoken.discord)
+    bot.run(os.getenv("DISCORD_TOKEN"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 PyYAML
 discord.py>=1.2.5
 emoji
+python-dotenv
+requests


### PR DESCRIPTION
resolves #31 

I have:
 - Removed ``docstoken.py``, and replaced it with a ``.env`` file
 - Replaced all channel IDs and category IDs with dotenv calls
 - Added ``requests`` to the requirements.txt, as it was missing
 - Added ``python-dotenv`` to parse the .env file (we could do this manually but no point)

Here is the format for the ``.env`` file:
```env
# The token the bot will use to authenticate with Discord
DISCORD_TOKEN=<DISCORD_TOKEN>
# Various channels
BOT_COMMANDS_CHANNEL=598564981989965854
MESSAGE_LOGS_CHANNEL=709176997233950790
MODERATION_LOGS_CHANNEL=709262930750865440
JOIN_LOGS_CHANNEL=718621539653648424
# Various categories
LIBRARIES_CATEGORY=361587040749355018
FRAMEWORKS_CATEGORY=361587387538604054
```

Should make it easier to use in servers that aren't the Roblox API server (though we still have hardcoded role names - perhaps consider removing!)